### PR TITLE
feat(forwarder): salty mixin

### DIFF
--- a/script/DeployGnosisForwarder.s.sol
+++ b/script/DeployGnosisForwarder.s.sol
@@ -68,11 +68,11 @@ contract DeployGnosisForwarder is Script {
         vm.startBroadcast(deployerPrivateKey);
 
         // Predict the forwarder address using the standard method
-        address predictedAddress = factory.predictForwarderAddress(mainnetRecipient);
+        address predictedAddress = factory.predictForwarderAddress(mainnetRecipient, bytes32(0));
         console.log("Predicted forwarder address:", predictedAddress);
 
         // Deploy the forwarder using the standard method
-        address forwarderAddress = factory.deployForwarder(mainnetRecipient);
+        address forwarderAddress = factory.deployForwarder(mainnetRecipient, bytes32(0));
         console.log("Deployed forwarder address:", forwarderAddress);
 
         // Verify the addresses match
@@ -113,14 +113,14 @@ contract DeployGnosisForwarder is Script {
             console.log("Deploying forwarder for recipient:", recipient);
 
             // Check if already deployed
-            address predictedAddress = factory.predictForwarderAddress(recipient);
+            address predictedAddress = factory.predictForwarderAddress(recipient, bytes32(0));
             if (predictedAddress.code.length > 0) {
                 console.log("Forwarder already exists for recipient:", recipient);
                 continue;
             }
 
             // Deploy the forwarder
-            address forwarderAddress = factory.deployForwarder(recipient);
+            address forwarderAddress = factory.deployForwarder(recipient, bytes32(0));
             console.log("Deployed forwarder at:", forwarderAddress);
         }
 
@@ -163,7 +163,7 @@ contract DeployGnosisForwarder is Script {
         console.log("[OK] Implementation verified");
 
         // Test prediction function works
-        address testPrediction = factory.predictForwarderAddress(address(0x1));
+        address testPrediction = factory.predictForwarderAddress(address(0x1), bytes32(0));
         require(testPrediction != address(0), "Factory prediction failed");
         console.log("[OK] Factory verified");
 

--- a/src/ForwarderFactory.sol
+++ b/src/ForwarderFactory.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8;
 
 import {LibClone} from "solady/utils/LibClone.sol";
+import {ERC20} from "solady/tokens/ERC20.sol";
 import "./interfaces/IForwarder.sol";
 
 /// @title ForwarderFactory
@@ -17,7 +18,7 @@ abstract contract ForwarderFactory {
 
     /// @notice Event emitted when a new forwarder is deployed
     event ForwarderDeployed(
-        address indexed implementation, address indexed mainnetRecipient, address indexed forwarder, bytes32 salt
+        address indexed implementation, address indexed mainnetRecipient, address indexed forwarder
     );
 
     /// @notice Error thrown when deployment fails
@@ -32,57 +33,64 @@ abstract contract ForwarderFactory {
 
     /// @notice Deploy a new forwarder contract deterministically using LibClone
     /// @param mainnetRecipient The mainnet address that will receive tokens
+    /// @param salt The salt used for deterministic deployment
     /// @return forwarder The address of the deployed forwarder contract
-    function deployForwarder(address mainnetRecipient) public returns (address payable forwarder) {
+    function deployForwarder(address mainnetRecipient, bytes32 salt) public returns (address payable forwarder) {
         require(mainnetRecipient != address(0), "Invalid recipient");
 
-        /// Generate deterministic salt based on mainnet recipient
-        bytes32 salt = keccak256(abi.encodePacked(mainnetRecipient));
-
         /// Deploy using LibClone's cloneDeterministic (minimal proxy)
-        forwarder = payable(LibClone.cloneDeterministic(implementation, salt));
+        forwarder = payable(LibClone.cloneDeterministic(implementation, calculateSalt(mainnetRecipient, salt)));
 
         require(forwarder != address(0), DeploymentFailed());
 
         /// Initialize the deployed forwarder
         IForwarder(forwarder).initialize(mainnetRecipient);
 
-        emit ForwarderDeployed(implementation, mainnetRecipient, forwarder, salt);
+        emit ForwarderDeployed(implementation, mainnetRecipient, forwarder);
     }
 
     /// @notice Predict the address of a forwarder contract
     /// @param mainnetRecipient The mainnet address that will receive tokens
+    /// @param salt The salt used for deterministic address prediction
     /// @return The predicted address of the forwarder contract
-    function predictForwarderAddress(address mainnetRecipient) public view returns (address) {
-        bytes32 salt = keccak256(abi.encodePacked(mainnetRecipient));
-        return LibClone.predictDeterministicAddress(implementation, salt, address(this));
+    function predictForwarderAddress(address mainnetRecipient, bytes32 salt) public view returns (address) {
+        return
+            LibClone.predictDeterministicAddress(implementation, calculateSalt(mainnetRecipient, salt), address(this));
     }
 
     /// @notice Deploy forwarder if it doesn't exist, otherwise return existing address
     /// @param mainnetRecipient The mainnet address that will receive tokens
+    /// @param salt The salt used for deterministic address prediction
     /// @return forwarder The address of the forwarder contract
-    function getOrDeployForwarder(address mainnetRecipient) external returns (address payable forwarder) {
-        forwarder = payable(predictForwarderAddress(mainnetRecipient));
+    function getOrDeployForwarder(address mainnetRecipient, bytes32 salt)
+        external
+        returns (address payable forwarder)
+    {
+        forwarder = payable(predictForwarderAddress(mainnetRecipient, salt));
 
         /// Check if forwarder already exists by checking if it has code
         if (forwarder.code.length == 0) {
-            forwarder = deployForwarder(mainnetRecipient);
+            forwarder = deployForwarder(mainnetRecipient, salt);
         }
     }
 
     /// @notice Batch deploy multiple forwarders
     /// @param mainnetRecipients Array of mainnet recipient addresses
     /// @return forwarderAddresses Array of deployed forwarder addresses
-    function batchDeployForwarders(address[] calldata mainnetRecipients)
+    function batchDeployForwarders(address[] calldata mainnetRecipients, bytes32[] calldata salts)
         external
         returns (address payable[] memory forwarderAddresses)
     {
-        require(mainnetRecipients.length > 0, "Empty recipients array");
+        require(mainnetRecipients.length == salts.length, "Mismatched arrays");
 
         forwarderAddresses = new address payable[](mainnetRecipients.length);
 
-        for (uint256 i = 0; i < mainnetRecipients.length; i++) {
-            forwarderAddresses[i] = deployForwarder(mainnetRecipients[i]);
+        for (uint256 i = 0; i < mainnetRecipients.length;) {
+            forwarderAddresses[i] = deployForwarder(mainnetRecipients[i], salts[i]);
+
+            unchecked {
+                ++i;
+            }
         }
     }
 
@@ -90,5 +98,72 @@ abstract contract ForwarderFactory {
     /// @return The implementation contract address
     function getImplementation() external view returns (address) {
         return implementation;
+    }
+
+    /// @notice Struct to define forwarder deployment and token forwarding configuration
+    struct ForwarderConfig {
+        bytes32 salt;
+        address[] tokens;
+    }
+
+    /// @notice Deploy multiple forwarders and immediately forward specified tokens from each
+    /// @param mainnetRecipient The mainnet address that will receive tokens
+    /// @param configs Array of ForwarderConfig structs, each containing salt and tokens to forward
+    /// @return forwarders Array of deployed forwarder addresses
+    function deployAndForwardTokens(address mainnetRecipient, ForwarderConfig[] calldata configs)
+        external
+        returns (address payable[] memory forwarders)
+    {
+        forwarders = new address payable[](configs.length);
+
+        for (uint256 i = 0; i < configs.length;) {
+            ForwarderConfig calldata config = configs[i];
+
+            // Deploy the forwarder
+            address payable forwarder = deployForwarder(mainnetRecipient, config.salt);
+            forwarders[i] = forwarder;
+
+            // Forward each specified token from this forwarder
+            for (uint256 j = 0; j < config.tokens.length;) {
+                address token = config.tokens[j];
+
+                if (token == address(0)) {
+                    // Forward native token if it has a balance
+                    if (forwarder.balance > 0) {
+                        IForwarder(forwarder).forwardNative();
+                    }
+                } else {
+                    // Forward ERC20 token if it has a balance
+                    // Use try/catch to handle invalid tokens gracefully
+                    try ERC20(token).balanceOf(forwarder) returns (uint256 balance) {
+                        if (balance > 0) {
+                            try IForwarder(forwarder).forwardToken(token) {
+                                // Token forwarded successfully
+                            } catch {
+                                // Failed to forward token - continue with next token
+                            }
+                        }
+                    } catch {
+                        // Failed to get balance - continue with next token
+                    }
+                }
+
+                unchecked {
+                    ++j;
+                }
+            }
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @notice Calculate the salt used for deterministic address prediction
+    /// @param mainnetRecipient The mainnet address that will receive tokens
+    /// @param salt The salt used for deterministic address prediction
+    /// @return The salt used for deterministic address prediction
+    function calculateSalt(address mainnetRecipient, bytes32 salt) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(mainnetRecipient, salt));
     }
 }

--- a/src/interfaces/IForwarder.sol
+++ b/src/interfaces/IForwarder.sol
@@ -29,11 +29,6 @@ interface IForwarder {
     /// @param tokens Array of token addresses to forward
     function batchForwardTokens(address[] calldata tokens) external;
 
-    /// @notice Get the balance of a specific token
-    /// @param token The token address (use address(0) for native token)
-    /// @return The balance of the token
-    function getBalance(address token) external view returns (uint256);
-
     /// @notice Get the mainnet recipient address
     /// @return The mainnet recipient address
     function mainnetRecipient() external view returns (address);

--- a/test/DeployGnosisForwarder.t.sol
+++ b/test/DeployGnosisForwarder.t.sol
@@ -38,10 +38,10 @@ contract DeployGnosisForwarderTest is Test {
         address testRecipient = address(0x1234567890123456789012345678901234567890);
 
         // Predict the forwarder address
-        address predictedAddress = factory.predictForwarderAddress(testRecipient);
+        address predictedAddress = factory.predictForwarderAddress(testRecipient, bytes32(0));
 
         // Deploy the forwarder
-        address deployedAddress = factory.deployForwarder(testRecipient);
+        address deployedAddress = factory.deployForwarder(testRecipient, bytes32(0));
 
         // Verify the addresses match
         assertEq(predictedAddress, deployedAddress);
@@ -64,8 +64,8 @@ contract DeployGnosisForwarderTest is Test {
             address recipient = recipients[i];
 
             // Predict and deploy
-            address predicted = factory.predictForwarderAddress(recipient);
-            address deployed = factory.deployForwarder(recipient);
+            address predicted = factory.predictForwarderAddress(recipient, bytes32(0));
+            address deployed = factory.deployForwarder(recipient, bytes32(0));
 
             assertEq(predicted, deployed);
 
@@ -95,15 +95,15 @@ contract DeployGnosisForwarderTest is Test {
         // Test that predictions are consistent within the same factory instance
         address testRecipient = vm.addr(99);
 
-        address predicted1 = factory.predictForwarderAddress(testRecipient);
-        address predicted2 = factory.predictForwarderAddress(testRecipient);
+        address predicted1 = factory.predictForwarderAddress(testRecipient, bytes32(0));
+        address predicted2 = factory.predictForwarderAddress(testRecipient, bytes32(0));
 
         // Predictions should be the same for the same recipient and factory
         assertEq(predicted1, predicted2, "Same factory predictions should match");
 
         // Now test that different factories have different implementations
         GnosisForwarderFactory factory2 = new GnosisForwarderFactory();
-        address predicted3 = factory2.predictForwarderAddress(testRecipient);
+        address predicted3 = factory2.predictForwarderAddress(testRecipient, bytes32(0));
 
         // Different factories will have different implementations, so different predictions
         assertTrue(predicted1 != predicted3, "Different factories should have different predictions");
@@ -134,10 +134,10 @@ contract DeployGnosisForwarderTest is Test {
         address recipient = vm.addr(50);
 
         // Deploy first forwarder
-        address forwarder1 = factory.deployForwarder(recipient);
+        address forwarder1 = factory.deployForwarder(recipient, bytes32(0));
 
         // Use getOrDeployForwarder for second attempt - this handles duplicates gracefully
-        address forwarder2 = factory.getOrDeployForwarder(recipient);
+        address forwarder2 = factory.getOrDeployForwarder(recipient, bytes32(0));
 
         assertEq(forwarder1, forwarder2);
     }
@@ -154,7 +154,7 @@ contract DeployGnosisForwarderTest is Test {
         address recipient = vm.addr(60);
 
         // Deploy via factory
-        address forwarderAddr = factory.deployForwarder(recipient);
+        address forwarderAddr = factory.deployForwarder(recipient, bytes32(0));
         GnosisForwarder forwarder = GnosisForwarder(payable(forwarderAddr));
 
         // Should be initialized
@@ -168,7 +168,7 @@ contract DeployGnosisForwarderTest is Test {
 
     function testBridgeConfigurationInDeployment() public {
         // Deploy forwarder and check bridge configuration
-        address forwarderAddr = factory.deployForwarder(mainnetRecipient);
+        address forwarderAddr = factory.deployForwarder(mainnetRecipient, bytes32(0));
         GnosisForwarder forwarder = GnosisForwarder(payable(forwarderAddr));
 
         assertTrue(address(forwarder.OMNIBRIDGE()) != address(0) && address(forwarder.XDAI_BRIDGE()) != address(0));

--- a/test/Forwarder.t.sol
+++ b/test/Forwarder.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 import "../src/Forwarder.sol";
 import "../src/forwarders/gnosis/GnosisForwarderFactory.sol";
 import {ERC20} from "solady/tokens/ERC20.sol";
+import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 
 /// @title TestERC20
 /// @notice Simple ERC20 token for testing
@@ -33,17 +34,25 @@ contract TestERC20 is ERC20 {
 /// @title TestForwarder
 /// @notice Concrete implementation of Forwarder for testing
 contract TestForwarder is Forwarder {
+    using SafeTransferLib for address;
+
     address public constant MOCK_BRIDGE = 0x1234567890123456789012345678901234567890;
 
     function _bridgeToken(address token, uint256 amount, address recipient) internal override {
+        // Transfer tokens to simulate bridging
+        token.safeTransfer(MOCK_BRIDGE, amount);
+
         // Mock bridge call
         (bool success,) = MOCK_BRIDGE.call(abi.encodeCall(this.bridgeToken, (token, amount, recipient)));
         require(success, BridgeFailed());
     }
 
     function _bridgeNative(uint256 amount, address recipient) internal override {
-        // Mock bridge call
-        (bool success,) = MOCK_BRIDGE.call{value: amount}(abi.encodeCall(this.bridgeNative, (amount, recipient)));
+        // Send native tokens to simulate bridging
+        MOCK_BRIDGE.safeTransferETH(amount);
+
+        // Mock bridge call (no value needed since we already sent it)
+        (bool success,) = MOCK_BRIDGE.call(abi.encodeCall(this.bridgeNative, (amount, recipient)));
         require(success, BridgeFailed());
     }
 
@@ -111,23 +120,23 @@ contract ForwarderTest is Test {
 
     function testFactoryPreventsDuplicateDeployment() public {
         // Deploy first forwarder
-        address payable forwarder1 = factory.deployForwarder(mainnetRecipient);
+        address payable forwarder1 = factory.deployForwarder(mainnetRecipient, bytes32(0));
 
         // Verify it exists
         assertTrue(forwarder1.code.length > 0);
 
         // Try to deploy again - should revert with DeploymentFailed since the address already has code
         vm.expectRevert(ForwarderFactory.DeploymentFailed.selector);
-        factory.deployForwarder(mainnetRecipient);
+        factory.deployForwarder(mainnetRecipient, bytes32(0));
     }
 
     function testGetOrDeployForwarder() public {
         // First call should deploy
-        address payable forwarder1 = factory.getOrDeployForwarder(mainnetRecipient);
+        address payable forwarder1 = factory.getOrDeployForwarder(mainnetRecipient, bytes32(0));
         assertTrue(forwarder1 != address(0));
 
         // Second call should return existing
-        address payable forwarder2 = factory.getOrDeployForwarder(mainnetRecipient);
+        address payable forwarder2 = factory.getOrDeployForwarder(mainnetRecipient, bytes32(0));
         assertEq(forwarder1, forwarder2);
     }
 
@@ -210,13 +219,11 @@ contract ForwarderTest is Test {
         // Use vm.deal to set native balance directly
         vm.deal(address(forwarder), 1 ether);
 
-        // Mock the bridge call to succeed
-        vm.mockCall(
-            mockBridge, 1 ether, abi.encodeCall(forwarder.bridgeNative, (1 ether, mainnetRecipient)), abi.encode(true)
-        );
+        // Mock the bridge call to succeed (no value since ETH is transferred separately)
+        vm.mockCall(mockBridge, abi.encodeCall(forwarder.bridgeNative, (1 ether, mainnetRecipient)), abi.encode(true));
 
-        // Expect the bridge call
-        vm.expectCall(mockBridge, 1 ether, abi.encodeCall(forwarder.bridgeNative, (1 ether, mainnetRecipient)));
+        // Expect the bridge call (no value since ETH is transferred separately)
+        vm.expectCall(mockBridge, abi.encodeCall(forwarder.bridgeNative, (1 ether, mainnetRecipient)));
 
         // Forward native tokens
         vm.expectEmit(true, false, false, true);
@@ -232,16 +239,11 @@ contract ForwarderTest is Test {
         // Use vm.deal to set native balance directly
         vm.deal(address(forwarder), 1 ether);
 
-        // Mock the bridge call to succeed
-        vm.mockCall(
-            mockBridge,
-            0.5 ether,
-            abi.encodeCall(forwarder.bridgeNative, (0.5 ether, mainnetRecipient)),
-            abi.encode(true)
-        );
+        // Mock the bridge call to succeed (no value since ETH is transferred separately)
+        vm.mockCall(mockBridge, abi.encodeCall(forwarder.bridgeNative, (0.5 ether, mainnetRecipient)), abi.encode(true));
 
-        // Expect the bridge call
-        vm.expectCall(mockBridge, 0.5 ether, abi.encodeCall(forwarder.bridgeNative, (0.5 ether, mainnetRecipient)));
+        // Expect the bridge call (no value since ETH is transferred separately)
+        vm.expectCall(mockBridge, abi.encodeCall(forwarder.bridgeNative, (0.5 ether, mainnetRecipient)));
 
         // Forward specific amount
         vm.expectEmit(true, false, false, true);
@@ -338,7 +340,11 @@ contract ForwarderTest is Test {
         recipients[0] = mainnetRecipient;
         recipients[1] = vm.addr(99);
 
-        address payable[] memory forwarders = factory.batchDeployForwarders(recipients);
+        bytes32[] memory salts = new bytes32[](2);
+        salts[0] = bytes32(0);
+        salts[1] = bytes32(0);
+
+        address payable[] memory forwarders = factory.batchDeployForwarders(recipients, salts);
 
         assertEq(forwarders.length, 2);
         assertTrue(forwarders[0] != address(0));
@@ -348,25 +354,285 @@ contract ForwarderTest is Test {
 
     function testDeterministicAddresses() public {
         // Deploy forwarder for same recipient
-        address payable forwarder1 = factory.deployForwarder(mainnetRecipient);
+        address payable forwarder1 = factory.deployForwarder(mainnetRecipient, bytes32(0));
 
         // Create new factory (simulating deployment on different chain)
         GnosisForwarderFactory factory2 = new GnosisForwarderFactory();
 
         // Predict address from both factories
-        address predicted1 = factory.predictForwarderAddress(mainnetRecipient);
-        address predicted2 = factory2.predictForwarderAddress(mainnetRecipient);
+        address predicted1 = factory.predictForwarderAddress(mainnetRecipient, bytes32(0));
+        address predicted2 = factory2.predictForwarderAddress(mainnetRecipient, bytes32(0));
 
-        // The prediction should match the deployed address from the same factory
+        // Should be the same since they use the same implementation
         assertEq(forwarder1, predicted1);
 
-        // Note: Addresses will be different between factories because CREATE2 includes deployer address
-        // This is expected behavior - each factory creates different addresses
+        // Different factories on same chain will have different implementations
         assertTrue(predicted1 != predicted2);
 
         // Deploy from second factory and verify it matches its prediction
-        address payable forwarder2 = factory2.deployForwarder(mainnetRecipient);
+        address payable forwarder2 = factory2.deployForwarder(mainnetRecipient, bytes32(0));
         assertEq(forwarder2, predicted2);
+    }
+
+    function testDeployAndForwardTokens() public {
+        address testRecipient = vm.addr(123);
+
+        // Setup forwarder configs - empty tokens array since GnosisForwarder has complex validation
+        // and we're not on actual Gnosis chain
+        ForwarderFactory.ForwarderConfig[] memory configs = new ForwarderFactory.ForwarderConfig[](1);
+        configs[0].salt = bytes32(uint256(456));
+        configs[0].tokens = new address[](0);
+
+        // Deploy and forward tokens (should work with empty array)
+        address payable[] memory deployedForwarders = factory.deployAndForwardTokens(testRecipient, configs);
+
+        // Verify deployment
+        assertEq(deployedForwarders.length, 1);
+        assertTrue(deployedForwarders[0].code.length > 0);
+
+        // Verify initialization
+        GnosisForwarder deployedForwarderContract = GnosisForwarder(deployedForwarders[0]);
+        assertTrue(deployedForwarderContract.initialized());
+        assertEq(deployedForwarderContract.mainnetRecipient(), testRecipient);
+    }
+
+    function testDeployAndForwardTokensWithDifferentSalts() public {
+        address testRecipient = vm.addr(789);
+
+        // Setup configs for two different forwarders
+        ForwarderFactory.ForwarderConfig[] memory configs = new ForwarderFactory.ForwarderConfig[](2);
+        configs[0].salt = bytes32(uint256(111));
+        configs[0].tokens = new address[](0);
+        configs[1].salt = bytes32(uint256(222));
+        configs[1].tokens = new address[](0);
+
+        // Deploy both forwarders
+        address payable[] memory forwarders = factory.deployAndForwardTokens(testRecipient, configs);
+
+        // Should have different addresses due to different salts
+        assertEq(forwarders.length, 2);
+        assertTrue(forwarders[0] != forwarders[1]);
+
+        // Both should be properly initialized with same recipient
+        assertEq(GnosisForwarder(payable(forwarders[0])).mainnetRecipient(), testRecipient);
+        assertEq(GnosisForwarder(payable(forwarders[1])).mainnetRecipient(), testRecipient);
+    }
+
+    function testDeployAndForwardTokensEmptyArray() public {
+        address testRecipient = vm.addr(333);
+
+        // Should deploy successfully even with empty configs array
+        ForwarderFactory.ForwarderConfig[] memory configs = new ForwarderFactory.ForwarderConfig[](0);
+
+        address payable[] memory forwarders = factory.deployAndForwardTokens(testRecipient, configs);
+
+        assertEq(forwarders.length, 0);
+    }
+
+    function testDeployAndForwardTokensWithTestForwarder() public {
+        // Create a custom factory with TestForwarder for proper testing
+        ForwarderFactory testFactory = new TestForwarderFactory();
+
+        address testRecipient = vm.addr(999);
+        bytes32 salt = bytes32(uint256(777));
+
+        // Setup forwarder config with tokens to forward
+        ForwarderFactory.ForwarderConfig[] memory configs = new ForwarderFactory.ForwarderConfig[](1);
+        configs[0].salt = salt;
+        configs[0].tokens = new address[](2);
+        configs[0].tokens[0] = address(testToken); // ERC20 token
+        configs[0].tokens[1] = address(0); // Native token
+
+        // Predict the forwarder address
+        address predictedForwarder = testFactory.predictForwarderAddress(testRecipient, salt);
+
+        // Fund the predicted forwarder with tokens and native currency
+        testToken.mint(predictedForwarder, 500e18);
+        vm.deal(predictedForwarder, 2 ether);
+
+        // Get the forwarder contract for mocking
+        TestForwarder forwarder = TestForwarder(payable(predictedForwarder));
+
+        // Mock the bridge calls to succeed (no value for native call since ETH is transferred separately)
+        vm.mockCall(
+            mockBridge,
+            abi.encodeCall(forwarder.bridgeToken, (address(testToken), 500e18, testRecipient)),
+            abi.encode(true)
+        );
+        vm.mockCall(mockBridge, abi.encodeCall(forwarder.bridgeNative, (2 ether, testRecipient)), abi.encode(true));
+
+        // Expect the bridge calls (no value for native call)
+        vm.expectCall(mockBridge, abi.encodeCall(forwarder.bridgeToken, (address(testToken), 500e18, testRecipient)));
+        vm.expectCall(mockBridge, abi.encodeCall(forwarder.bridgeNative, (2 ether, testRecipient)));
+
+        // Expect events
+        vm.expectEmit(true, true, false, true);
+        emit TokensForwarded(address(testToken), 500e18, testRecipient);
+        vm.expectEmit(true, false, false, true);
+        emit NativeForwarded(2 ether, testRecipient);
+
+        // Deploy and forward tokens
+        address payable[] memory deployedForwarders = testFactory.deployAndForwardTokens(testRecipient, configs);
+
+        // Verify deployment
+        assertEq(deployedForwarders.length, 1);
+        assertEq(deployedForwarders[0], predictedForwarder);
+        assertTrue(deployedForwarders[0].code.length > 0);
+
+        // Verify initialization
+        TestForwarder deployedForwarderContract = TestForwarder(deployedForwarders[0]);
+        assertTrue(deployedForwarderContract.initialized());
+        assertEq(deployedForwarderContract.mainnetRecipient(), testRecipient);
+
+        // Verify tokens were forwarded (balances should be zero)
+        assertEq(testToken.balanceOf(deployedForwarders[0]), 0);
+        assertEq(deployedForwarders[0].balance, 0);
+    }
+
+    function testDeployAndForwardTokensMultipleForwarders() public {
+        // Create a custom factory with TestForwarder for proper testing
+        ForwarderFactory testFactory = new TestForwarderFactory();
+
+        address testRecipient = vm.addr(888);
+
+        // Create another test token
+        TestERC20 testToken2 = new TestERC20("Test Token 2", "TEST2");
+
+        // Setup configs for multiple forwarders with different token sets
+        ForwarderFactory.ForwarderConfig[] memory configs = new ForwarderFactory.ForwarderConfig[](3);
+
+        // First forwarder: only ERC20 token
+        configs[0].salt = bytes32(uint256(100));
+        configs[0].tokens = new address[](1);
+        configs[0].tokens[0] = address(testToken);
+
+        // Second forwarder: only native token
+        configs[1].salt = bytes32(uint256(200));
+        configs[1].tokens = new address[](1);
+        configs[1].tokens[0] = address(0);
+
+        // Third forwarder: both tokens
+        configs[2].salt = bytes32(uint256(300));
+        configs[2].tokens = new address[](2);
+        configs[2].tokens[0] = address(testToken2);
+        configs[2].tokens[1] = address(0);
+
+        // Predict forwarder addresses
+        address forwarder1 = testFactory.predictForwarderAddress(testRecipient, configs[0].salt);
+        address forwarder2 = testFactory.predictForwarderAddress(testRecipient, configs[1].salt);
+        address forwarder3 = testFactory.predictForwarderAddress(testRecipient, configs[2].salt);
+
+        // Fund the forwarders with their respective tokens
+        testToken.mint(forwarder1, 100e18);
+        vm.deal(forwarder2, 1 ether);
+        testToken2.mint(forwarder3, 200e18);
+        vm.deal(forwarder3, 2 ether);
+
+        // Mock bridge calls for all tokens
+        vm.mockCall(
+            mockBridge,
+            abi.encodeCall(TestForwarder.bridgeToken, (address(testToken), 100e18, testRecipient)),
+            abi.encode(true)
+        );
+        vm.mockCall(mockBridge, abi.encodeCall(TestForwarder.bridgeNative, (1 ether, testRecipient)), abi.encode(true));
+        vm.mockCall(
+            mockBridge,
+            abi.encodeCall(TestForwarder.bridgeToken, (address(testToken2), 200e18, testRecipient)),
+            abi.encode(true)
+        );
+        vm.mockCall(mockBridge, abi.encodeCall(TestForwarder.bridgeNative, (2 ether, testRecipient)), abi.encode(true));
+
+        // Deploy and forward tokens from all forwarders
+        address payable[] memory deployedForwarders = testFactory.deployAndForwardTokens(testRecipient, configs);
+
+        // Verify all forwarders were deployed
+        assertEq(deployedForwarders.length, 3);
+        assertEq(deployedForwarders[0], forwarder1);
+        assertEq(deployedForwarders[1], forwarder2);
+        assertEq(deployedForwarders[2], forwarder3);
+
+        // Verify all forwarders are properly initialized
+        for (uint256 i = 0; i < deployedForwarders.length; i++) {
+            TestForwarder forwarder = TestForwarder(deployedForwarders[i]);
+            assertTrue(forwarder.initialized());
+            assertEq(forwarder.mainnetRecipient(), testRecipient);
+        }
+
+        // Verify tokens were forwarded (balances should be zero)
+        assertEq(testToken.balanceOf(forwarder1), 0);
+        assertEq(forwarder2.balance, 0);
+        assertEq(testToken2.balanceOf(forwarder3), 0);
+        assertEq(forwarder3.balance, 0);
+    }
+
+    function testSaltFunctionality() public {
+        address testRecipient = vm.addr(555);
+        bytes32 salt1 = bytes32(uint256(1));
+        bytes32 salt2 = bytes32(uint256(2));
+        bytes32 salt3 = keccak256("custom salt");
+
+        // Predict addresses with different salts
+        address predicted1 = factory.predictForwarderAddress(testRecipient, salt1);
+        address predicted2 = factory.predictForwarderAddress(testRecipient, salt2);
+        address predicted3 = factory.predictForwarderAddress(testRecipient, salt3);
+
+        // All addresses should be different
+        assertTrue(predicted1 != predicted2);
+        assertTrue(predicted1 != predicted3);
+        assertTrue(predicted2 != predicted3);
+
+        // Deploy with each salt and verify they match predictions
+        address deployed1 = factory.deployForwarder(testRecipient, salt1);
+        address deployed2 = factory.deployForwarder(testRecipient, salt2);
+        address deployed3 = factory.deployForwarder(testRecipient, salt3);
+
+        assertEq(deployed1, predicted1);
+        assertEq(deployed2, predicted2);
+        assertEq(deployed3, predicted3);
+
+        // All should have same recipient but different addresses
+        assertEq(TestForwarder(payable(deployed1)).mainnetRecipient(), testRecipient);
+        assertEq(TestForwarder(payable(deployed2)).mainnetRecipient(), testRecipient);
+        assertEq(TestForwarder(payable(deployed3)).mainnetRecipient(), testRecipient);
+    }
+
+    function testSameSaltReproducesAddress() public {
+        address testRecipient = vm.addr(666);
+        bytes32 salt = keccak256("reproducible salt");
+
+        // Predict same address multiple times
+        address predicted1 = factory.predictForwarderAddress(testRecipient, salt);
+        address predicted2 = factory.predictForwarderAddress(testRecipient, salt);
+        address predicted3 = factory.predictForwarderAddress(testRecipient, salt);
+
+        // Should always be the same
+        assertEq(predicted1, predicted2);
+        assertEq(predicted2, predicted3);
+
+        // Deploy and verify it matches
+        address deployed = factory.deployForwarder(testRecipient, salt);
+        assertEq(deployed, predicted1);
+    }
+
+    function testCalculateSaltFunction() public {
+        address recipient1 = vm.addr(777);
+        address recipient2 = vm.addr(888);
+        bytes32 userSalt = keccak256("test salt");
+
+        // Calculate salts for different recipients with same user salt
+        bytes32 calculatedSalt1 = factory.calculateSalt(recipient1, userSalt);
+        bytes32 calculatedSalt2 = factory.calculateSalt(recipient2, userSalt);
+
+        // Should be different for different recipients
+        assertTrue(calculatedSalt1 != calculatedSalt2);
+
+        // Should be deterministic - same inputs produce same output
+        bytes32 calculatedSalt1Again = factory.calculateSalt(recipient1, userSalt);
+        assertEq(calculatedSalt1, calculatedSalt1Again);
+
+        // Should match expected keccak256(abi.encodePacked(recipient, salt))
+        bytes32 expectedSalt1 = keccak256(abi.encodePacked(recipient1, userSalt));
+        assertEq(calculatedSalt1, expectedSalt1);
     }
 
     function testBridgeFailure() public {
@@ -395,10 +661,9 @@ contract ForwarderTest is Test {
         // Set up native balance
         vm.deal(address(forwarder), 1 ether);
 
-        // Mock the bridge call to revert
+        // Mock the bridge call to revert (no value since ETH is transferred separately)
         vm.mockCallRevert(
             mockBridge,
-            1 ether,
             abi.encodeCall(forwarder.bridgeNative, (1 ether, mainnetRecipient)),
             abi.encodeWithSelector(Forwarder.BridgeFailed.selector)
         );
@@ -409,8 +674,14 @@ contract ForwarderTest is Test {
     }
 }
 
+/// @title TestForwarderFactory
+/// @notice Factory for TestForwarder contracts
+contract TestForwarderFactory is ForwarderFactory {
+    constructor() ForwarderFactory(address(new TestForwarder())) {}
+}
+
 /// @title GnosisForwarderTest
-/// @notice Test suite specifically for GnosisForwarder
+/// @notice Tests specifically for GnosisForwarder functionality
 contract GnosisForwarderTest is Test {
     GnosisForwarderFactory factory;
     GnosisForwarder forwarder;
@@ -425,7 +696,7 @@ contract GnosisForwarderTest is Test {
         factory = new GnosisForwarderFactory();
 
         // Deploy forwarder instance
-        address payable forwarderAddr = factory.deployForwarder(mainnetRecipient);
+        address payable forwarderAddr = factory.deployForwarder(mainnetRecipient, bytes32(0));
         forwarder = GnosisForwarder(forwarderAddr);
 
         // Deploy test token

--- a/test/GnosisChainForwarder.t.sol
+++ b/test/GnosisChainForwarder.t.sol
@@ -64,7 +64,7 @@ contract GnosisForwarderForkTest is Test {
         factory = new GnosisForwarderFactory();
 
         // Deploy forwarder instance
-        address payable forwarderAddr = factory.deployForwarder(mainnetRecipient);
+        address payable forwarderAddr = factory.deployForwarder(mainnetRecipient, bytes32(0));
         forwarder = GnosisForwarder(forwarderAddr);
 
         // Fund user account
@@ -195,13 +195,13 @@ contract GnosisForwarderForkTest is Test {
         address recipient2 = vm.addr(11);
 
         // Predict and deploy first forwarder
-        address predicted1 = factory.predictForwarderAddress(recipient1);
-        address forwarder1 = factory.deployForwarder(recipient1);
+        address predicted1 = factory.predictForwarderAddress(recipient1, bytes32(0));
+        address forwarder1 = factory.deployForwarder(recipient1, bytes32(0));
         assertEq(predicted1, forwarder1);
 
         // Predict and deploy second forwarder
-        address predicted2 = factory.predictForwarderAddress(recipient2);
-        address forwarder2 = factory.deployForwarder(recipient2);
+        address predicted2 = factory.predictForwarderAddress(recipient2, bytes32(0));
+        address forwarder2 = factory.deployForwarder(recipient2, bytes32(0));
         assertEq(predicted2, forwarder2);
 
         // Addresses should be different
@@ -212,7 +212,7 @@ contract GnosisForwarderForkTest is Test {
         assertEq(GnosisForwarder(payable(forwarder2)).mainnetRecipient(), recipient2);
 
         // Duplicate deployment returns the same address
-        address forwarder1Dup = factory.getOrDeployForwarder(recipient1);
+        address forwarder1Dup = factory.getOrDeployForwarder(recipient1, bytes32(0));
         assertEq(forwarder1, forwarder1Dup);
 
         // Batch deploy
@@ -222,8 +222,8 @@ contract GnosisForwarderForkTest is Test {
         recipients[2] = vm.addr(42);
 
         for (uint256 i = 0; i < recipients.length; i++) {
-            address predicted = factory.predictForwarderAddress(recipients[i]);
-            address deployed = factory.deployForwarder(recipients[i]);
+            address predicted = factory.predictForwarderAddress(recipients[i], bytes32(0));
+            address deployed = factory.deployForwarder(recipients[i], bytes32(0));
             assertEq(predicted, deployed);
 
             GnosisForwarder fw = GnosisForwarder(payable(deployed));


### PR DESCRIPTION
This PR:

1. Introduces a `salt` parameter to the `Factory.deployForwarder` function to allow for a `mainnetRecipient` to have multiple forwarders on L2s (meeting the case of assigning payment addresses per payee).