### PR TITLE
feat(governor): otoco-manager extension

### DIFF
--- a/src/Governor.sol
+++ b/src/Governor.sol
@@ -10,6 +10,8 @@ import {GovernorSettings} from "@openzeppelin/contracts/governance/extensions/Go
 import {GovernorPreventLateQuorum} from "@openzeppelin/contracts/governance/extensions/GovernorPreventLateQuorum.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 
+import {OtocoManager} from "./extensions/OtocoManager.sol";
+
 /// @title TokenGovernor
 /// @author Nexum Contributors
 contract Governor is
@@ -18,7 +20,8 @@ contract Governor is
     GovernorCountingSimple,
     GovernorVotes,
     GovernorVotesQuorumFraction,
-    GovernorPreventLateQuorum
+    GovernorPreventLateQuorum,
+    OtocoManager
 {
     constructor(
         string memory name,
@@ -34,6 +37,7 @@ contract Governor is
         GovernorVotesQuorumFraction(quorumPercentage)
         GovernorSettings(uint48(initialVotingDelay), uint32(initialVotingPeriod), initialProposalThreshold)
         GovernorPreventLateQuorum(lateQuorumExtension)
+        OtocoManager(address(this))
     {}
 
     /// @dev Override to resolve conflict between Governor and GovernorSettings

--- a/src/Governor.sol
+++ b/src/Governor.sol
@@ -14,6 +14,13 @@ import {OtocoManager} from "./extensions/OtocoManager.sol";
 
 /// @title TokenGovernor
 /// @author Nexum Contributors
+/// @notice A standard OpenZeppelin-based governance contract with sane defaults and extensions:
+/// - Simple counting mechanism
+/// - Token-based voting
+/// - Quorum fraction-based quorum calculation
+/// - Settings for voting delay, period, and proposal threshold
+/// - Prevent late quorum extension mechanism
+/// - OtocoManager extension for managing token-based proposals and voting
 contract Governor is
     OZGovernor,
     GovernorSettings,

--- a/src/extensions/OtocoManager.sol
+++ b/src/extensions/OtocoManager.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8;
+
+import "@openzeppelin/contracts/governance/Governor.sol";
+
+abstract contract OtocoManager is Governor {
+    address private _manager;
+
+    /// @dev Emitted when the manager is set.
+    event ManagerSet(address indexed oldManager, address indexed newManager);
+
+    /// @notice Initializes the manager address.
+    /// @param manager The initial manager address.
+    constructor(address manager) {
+        _setManager(manager);
+    }
+
+    /// @notice Retrieve the current manager address.
+    /// @return The current manager address.
+    function getManager() external view returns (address) {
+        return _manager;
+    }
+
+    /// @notice Sets the manager address.
+    /// @param newManager The new manager address.
+    function setManager(address newManager) public virtual onlyGovernance {
+        _setManager(newManager);
+    }
+
+    /// @notice Internal function to set the manager address.
+    /// @param newManager The new manager address.
+    function _setManager(address newManager) internal {
+        address oldManager = _manager;
+        _manager = newManager;
+        emit ManagerSet(oldManager, newManager);
+    }
+
+    /// @dev Here we stub out the `isManagerProposal` function. Always returns false.
+    /// @return Always returns false.
+    function isManagerProposal(uint256) public pure virtual returns (bool) {
+        return false;
+    }
+}

--- a/src/extensions/OtocoManager.sol
+++ b/src/extensions/OtocoManager.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.8;
 
 import "@openzeppelin/contracts/governance/Governor.sol";
 
+/// @title OtocoManager
+/// @author Nexum Contributors
+/// @notice Abstract contract implementing ABI for use with https://otoco.io.
 abstract contract OtocoManager is Governor {
     address private _manager;
 

--- a/src/forwarders/gnosis/GnosisForwarder.sol
+++ b/src/forwarders/gnosis/GnosisForwarder.sol
@@ -6,6 +6,7 @@ import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 import {IOmnibridge, IxDaiBridge, IBridgedToken, IAMBBridge} from "./interfaces/IGnosisBridges.sol";
 
 /// @title GnosisForwarder
+/// @author Nexum Contributors
 /// @notice Concrete implementation of Forwarder for Gnosis Chain using Omnibridge/AMB
 /// @dev Forwards tokens from Gnosis Chain to Ethereum mainnet via the canonical bridge
 contract GnosisForwarder is Forwarder {

--- a/src/forwarders/gnosis/GnosisForwarderFactory.sol
+++ b/src/forwarders/gnosis/GnosisForwarderFactory.sol
@@ -5,6 +5,7 @@ import "../../ForwarderFactory.sol";
 import "./GnosisForwarder.sol";
 
 /// @title GnosisForwarderFactory
+/// @author Nexum Contributors
 /// @notice Factory contract for deploying GnosisForwarder contracts
 /// @dev Inherits from ForwarderFactory and deploys GnosisForwarder implementation
 contract GnosisForwarderFactory is ForwarderFactory {

--- a/src/forwarders/gnosis/interfaces/IGnosisBridges.sol
+++ b/src/forwarders/gnosis/interfaces/IGnosisBridges.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8;
 
 /// @title IOmnibridge
+/// @author Nexum Contributors
 /// @notice Interface for the Omnibridge contract on Gnosis Chain
 /// @dev Used for bridging ERC20 tokens between Gnosis Chain and Ethereum mainnet
 interface IOmnibridge {

--- a/src/interfaces/IForwarder.sol
+++ b/src/interfaces/IForwarder.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8;
 
 /// @title IForwarder
+/// @author Nexum Contributors
 /// @notice Interface for Forwarder contracts
 /// @dev Used to interact with forwarder implementations in a type-safe manner
 interface IForwarder {

--- a/test/Deployer.t.sol
+++ b/test/Deployer.t.sol
@@ -19,10 +19,15 @@ contract DeployerTest is TestHelper {
         assertValidDeployment(tokenAddress, governorAddress, splitterAddress, TOKEN_NAME, GOVERNOR_NAME);
 
         Token token = Token(tokenAddress);
+        Governor governor = Governor(payable(governorAddress));
+
         assertEq(token.balanceOf(USER1), 1000 * 10 ** 18);
         assertEq(token.balanceOf(USER2), 2000 * 10 ** 18);
         assertEq(totalDistributed, 3000 * 10 ** 18);
         assertEq(splitterAddress, address(0)); // No splitter deployed
+
+        // Verify OtocoManager extension: Governor should be set as Manager upon deployment
+        assertEq(governor.getManager(), governorAddress);
     }
 
     function testDeploymentWithSplitter() public {

--- a/test/Forwarder.t.sol
+++ b/test/Forwarder.t.sol
@@ -614,7 +614,7 @@ contract ForwarderTest is Test {
         assertEq(deployed, predicted1);
     }
 
-    function testCalculateSaltFunction() public {
+    function testCalculateSaltFunction() public view {
         address recipient1 = vm.addr(777);
         address recipient2 = vm.addr(888);
         bytes32 userSalt = keccak256("test salt");

--- a/test/GovernanceIntegration.t.sol
+++ b/test/GovernanceIntegration.t.sol
@@ -125,6 +125,9 @@ contract GovernanceIntegrationTest is TestHelper {
 
         // Verify quorum calculation (50% of total supply = 5000e18)
         assertEq(governor.quorum(block.number - 1), 5000e18);
+
+        // Verify OtocoManager extension: Governor should be set as Manager upon deployment
+        assertEq(governor.getManager(), address(governor));
     }
 
     /**

--- a/test/OtocoManager.t.sol
+++ b/test/OtocoManager.t.sol
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8;
+
+import "./TestHelper.sol";
+import "../src/Deployer.sol";
+import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
+
+/**
+ * @title OtocoManagerTest
+ * @dev Comprehensive tests for the OtocoManager extension functionality.
+ *
+ * These tests verify:
+ * - Manager is correctly set to Governor address upon deployment
+ * - getManager() returns the correct manager address
+ * - setManager() requires governance and works correctly
+ * - isManagerProposal() stub functionality
+ * - Manager address can be changed through governance
+ * - Proper event emission for manager changes
+ */
+contract OtocoManagerTest is TestHelper {
+    Token public token;
+    Governor public governor;
+
+    // Test addresses
+    address public constant PROPOSER = address(0x10);
+    address public constant VOTER1 = address(0x11);
+    address public constant VOTER2 = address(0x12);
+    address public constant NEW_MANAGER = address(0x20);
+
+    function setUp() public {
+        // Create token distribution for governance testing
+        AbstractDeployer.TokenDistribution[] memory distributions = new AbstractDeployer.TokenDistribution[](3);
+        distributions[0] = AbstractDeployer.TokenDistribution({
+            recipient: PROPOSER,
+            amount: 1000e18 // 10% - enough to create proposals
+        });
+        distributions[1] = AbstractDeployer.TokenDistribution({
+            recipient: VOTER1,
+            amount: 5000e18 // 50% - enough to reach quorum alone
+        });
+        distributions[2] = AbstractDeployer.TokenDistribution({
+            recipient: VOTER2,
+            amount: 4000e18 // 40% - additional voting power
+        });
+
+        // Deploy governance system
+        AbstractDeployer.SplitterConfig memory emptySplitterConfig;
+
+        vm.recordLogs();
+        new TestableDeployer(createBasicTokenConfig(), createBasicGovernorConfig(), emptySplitterConfig, distributions);
+
+        // Extract deployed addresses
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        (address tokenAddress, address governorAddress,,,) = extractDeploymentAddresses(logs);
+
+        token = Token(tokenAddress);
+        governor = Governor(payable(governorAddress));
+
+        // Delegate voting power
+        vm.prank(PROPOSER);
+        token.delegate(PROPOSER);
+
+        vm.prank(VOTER1);
+        token.delegate(VOTER1);
+
+        vm.prank(VOTER2);
+        token.delegate(VOTER2);
+
+        // Move forward one block to activate delegation
+        vm.roll(block.number + 1);
+    }
+
+    /// @notice Test that the Governor sets itself as Manager upon deployment
+    function testInitialManagerSetup() public view {
+        // Verify that the Governor address is set as the Manager
+        assertEq(governor.getManager(), address(governor));
+    }
+
+    /// @notice Test getManager() function returns correct address
+    function testGetManager() public view {
+        address manager = governor.getManager();
+        assertEq(manager, address(governor));
+    }
+
+    /// @notice Test that setManager() requires governance (onlyGovernance modifier)
+    function testSetManagerRequiresGovernance() public {
+        // Attempt to call setManager directly should fail
+        vm.expectRevert(abi.encodeWithSelector(IGovernor.GovernorOnlyExecutor.selector, address(this)));
+        governor.setManager(NEW_MANAGER);
+
+        // Test with different addresses
+        vm.prank(PROPOSER);
+        vm.expectRevert(abi.encodeWithSelector(IGovernor.GovernorOnlyExecutor.selector, PROPOSER));
+        governor.setManager(NEW_MANAGER);
+
+        vm.prank(VOTER1);
+        vm.expectRevert(abi.encodeWithSelector(IGovernor.GovernorOnlyExecutor.selector, VOTER1));
+        governor.setManager(NEW_MANAGER);
+    }
+
+    /// @notice Test setManager() through governance proposal
+    function testSetManagerThroughGovernance() public {
+        // Create proposal to change manager
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+
+        targets[0] = address(governor);
+        values[0] = 0;
+        calldatas[0] = abi.encodeWithSelector(governor.setManager.selector, NEW_MANAGER);
+
+        // Create proposal
+        vm.prank(PROPOSER);
+        uint256 proposalId = governor.propose(targets, values, calldatas, "Change Manager to NEW_MANAGER");
+
+        // Wait for voting delay
+        vm.roll(block.number + VOTING_DELAY + 1);
+
+        // Vote in favor (VOTER1 has 50% which is enough for quorum and majority)
+        vm.prank(VOTER1);
+        governor.castVote(proposalId, 1); // 1 = For
+
+        // Wait for voting period to end
+        vm.roll(block.number + VOTING_PERIOD + 1);
+
+        // Verify proposal succeeded
+        assertEq(uint256(governor.state(proposalId)), uint256(IGovernor.ProposalState.Succeeded));
+
+        // Expect ManagerSet event
+        vm.expectEmit(true, true, false, true);
+        emit ManagerSet(address(governor), NEW_MANAGER);
+
+        // Execute proposal
+        governor.execute(targets, values, calldatas, keccak256(bytes("Change Manager to NEW_MANAGER")));
+
+        // Verify manager was changed
+        assertEq(governor.getManager(), NEW_MANAGER);
+    }
+
+    /// @notice Test ManagerSet event emission
+    function testManagerSetEventEmission() public {
+        // Create proposal to change manager
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+
+        targets[0] = address(governor);
+        values[0] = 0;
+        calldatas[0] = abi.encodeWithSelector(governor.setManager.selector, NEW_MANAGER);
+
+        vm.prank(PROPOSER);
+        uint256 proposalId = governor.propose(targets, values, calldatas, "Change Manager Event Test");
+
+        vm.roll(block.number + VOTING_DELAY + 1);
+
+        vm.prank(VOTER1);
+        governor.castVote(proposalId, 1);
+
+        vm.roll(block.number + VOTING_PERIOD + 1);
+
+        // Expect specific event emission
+        vm.expectEmit(true, true, false, true);
+        emit ManagerSet(address(governor), NEW_MANAGER);
+
+        governor.execute(targets, values, calldatas, keccak256(bytes("Change Manager Event Test")));
+    }
+
+    /// @notice Test isManagerProposal() stub function
+    function testIsManagerProposal() public view {
+        // Test with various proposal IDs - should always return false as it's a stub
+        assertEq(governor.isManagerProposal(0), false);
+        assertEq(governor.isManagerProposal(1), false);
+        assertEq(governor.isManagerProposal(999), false);
+        assertEq(governor.isManagerProposal(type(uint256).max), false);
+    }
+
+    /// @notice Test multiple manager changes
+    function testMultipleManagerChanges() public {
+        address MANAGER2 = address(0x21);
+        address MANAGER3 = address(0x22);
+
+        // First change: Governor -> NEW_MANAGER
+        _changeManagerThroughGovernance(NEW_MANAGER, "Change to NEW_MANAGER");
+        assertEq(governor.getManager(), NEW_MANAGER);
+
+        // Add delay between proposals to prevent state conflicts
+        vm.roll(block.number + 10);
+
+        // Second change: NEW_MANAGER -> MANAGER2
+        _changeManagerThroughGovernance(MANAGER2, "Change to MANAGER2");
+        assertEq(governor.getManager(), MANAGER2);
+
+        // Add delay between proposals to prevent state conflicts
+        vm.roll(block.number + 10);
+
+        // Third change: MANAGER2 -> MANAGER3
+        _changeManagerThroughGovernance(MANAGER3, "Change to MANAGER3");
+        assertEq(governor.getManager(), MANAGER3);
+
+        // Add delay between proposals to prevent state conflicts
+        vm.roll(block.number + 10);
+
+        // Change back to Governor
+        _changeManagerThroughGovernance(address(governor), "Change back to Governor");
+        assertEq(governor.getManager(), address(governor));
+    }
+
+    /// @notice Test setting manager to zero address
+    function testSetManagerToZeroAddress() public {
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+
+        targets[0] = address(governor);
+        values[0] = 0;
+        calldatas[0] = abi.encodeWithSelector(governor.setManager.selector, address(0));
+
+        vm.prank(PROPOSER);
+        uint256 proposalId = governor.propose(targets, values, calldatas, "Set Manager to Zero Address");
+
+        vm.roll(block.number + VOTING_DELAY + 1);
+
+        vm.prank(VOTER1);
+        governor.castVote(proposalId, 1);
+
+        vm.roll(block.number + VOTING_PERIOD + 1);
+
+        // This should work - the extension doesn't prevent setting to zero address
+        governor.execute(targets, values, calldatas, keccak256(bytes("Set Manager to Zero Address")));
+
+        assertEq(governor.getManager(), address(0));
+    }
+
+    /// @notice Test manager functionality persists across multiple proposals
+    function testManagerPersistenceAcrossProposals() public {
+        // Change manager first
+        _changeManagerThroughGovernance(NEW_MANAGER, "Initial Manager Change");
+        assertEq(governor.getManager(), NEW_MANAGER);
+
+        // Create and execute another unrelated proposal
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+
+        targets[0] = address(token);
+        values[0] = 0;
+        calldatas[0] = abi.encodeWithSelector(token.mint.selector, VOTER2, 1000e18);
+
+        vm.prank(PROPOSER);
+        uint256 proposalId = governor.propose(targets, values, calldatas, "Mint tokens");
+
+        vm.roll(block.number + VOTING_DELAY + 1);
+
+        vm.prank(VOTER1);
+        governor.castVote(proposalId, 1);
+
+        vm.roll(block.number + VOTING_PERIOD + 1);
+
+        governor.execute(targets, values, calldatas, keccak256(bytes("Mint tokens")));
+
+        // Manager should still be NEW_MANAGER
+        assertEq(governor.getManager(), NEW_MANAGER);
+    }
+
+    /// @notice Helper function to change manager through governance
+    function _changeManagerThroughGovernance(address newManager, string memory description) internal {
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+
+        targets[0] = address(governor);
+        values[0] = 0;
+        calldatas[0] = abi.encodeWithSelector(governor.setManager.selector, newManager);
+
+        vm.prank(PROPOSER);
+        uint256 proposalId = governor.propose(targets, values, calldatas, description);
+
+        // Wait for voting delay
+        vm.roll(block.number + VOTING_DELAY + 1);
+
+        // Vote with sufficient power to pass
+        vm.prank(VOTER1);
+        governor.castVote(proposalId, 1);
+
+        // Wait for voting period to end
+        vm.roll(block.number + VOTING_PERIOD + 1);
+
+        // Verify proposal succeeded before execution
+        assertEq(uint256(governor.state(proposalId)), uint256(IGovernor.ProposalState.Succeeded));
+
+        // Execute proposal
+        governor.execute(targets, values, calldatas, keccak256(bytes(description)));
+    }
+
+    /// @notice Event to match the one in OtocoManager
+    event ManagerSet(address indexed oldManager, address indexed newManager);
+}


### PR DESCRIPTION
This PR builds on #3:

1. Adds an `OtocoManager` extension for the Governor, so as to provide an ABI-compliant contract for Otoco's indexing.